### PR TITLE
Build library with Java 25

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 8, 11, 17, 21, 23, 24 ]
+        version: [ 8, 11, 17, 21, 23, 24, 25 ]
     steps:
       - uses: actions/checkout@v4
 
-      # Java24 is used to build library (but -target=8)
-      - name: Set up JDK 24 (for building)
+      # Java25 is used to build library (but -target=8)
+      - name: Set up JDK 25 (for building)
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn -B --color=always -DskipTests package

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           server-id: central1
           server-username: MAVEN_CENTRAL_LOGIN
           server-password: MAVEN_CENTRAL_PASSWORD
@@ -63,6 +63,15 @@ jobs:
         run: |
           echo "====== Updating version to $RELEASE_VERSION ======"
           mvn -B --color=always versions:set -DnewVersion=$RELEASE_VERSION
+
+          mv README.md README.md.bak
+          awk -v v="$RELEASE_VERSION" '\
+            doer_artifact { sub(/<version>[^<]+<\/version>/, "<version>" v "</version>"); doer_artifact=0 }\
+            /<artifactId>doer<\/artifactId>/ { doer_artifact=1 }\
+            { print }\
+          ' README.md.bak > README.md
+          rm README.md.bak
+
           mvn -B --color=always versions:commit
 
           echo "====== Commiting and tagging ======"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ processing of complex workflows.
 
 Starting from java 23 you need to enable annotation processing explicitly.
 
-Set `-Dmaven.compiler.proc=full` to enable ALL annotation processors, or explicitly enable doer annotation processor.
+Set `-Dmaven.compiler.proc=full` to enable ALL annotation processors.
+
+Or explicitly enable doer annotation processor:
 
 ```xml
 <build>


### PR DESCRIPTION
Use JDK 25 to build the library, but target is set to 8. Also library is tested with java8.
So library can be used in applications built with JDK from 1.8 to 25

Github workflow script is updated to update README.md when new version is published.